### PR TITLE
Persist isRelative checkbox state

### DIFF
--- a/src/src/app/components/nav.tsx
+++ b/src/src/app/components/nav.tsx
@@ -1,7 +1,7 @@
 import humanResults from "../../../benchmark/results-human.json";
 import { useMemo } from "react";
 import { Popover, PopoverContent, PopoverTrigger } from "./popover";
-import { useParams, useRouter } from "next/navigation";
+import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { ChevronDownIcon } from "./icons";
 import Link from "next/link";
 import { GithubIcon, ClipboardListIcon } from "lucide-react";
@@ -24,6 +24,7 @@ type HeaderProps = {
 export const QuestionSelect = () => {
   const router = useRouter();
   const { pipename } = useParams();
+  const searchParams = useSearchParams();
 
   // Build question options from humanResults
   const questionOptions = useMemo(() => {
@@ -48,10 +49,12 @@ export const QuestionSelect = () => {
 
   // Handle select change: redirect if not All
   const handleQuestionChange = (value: string) => {
+    // Preserve existing query parameters
+    const params = new URLSearchParams(searchParams);
     if (value) {
-      router.push(`/questions/${encodeURIComponent(value)}`);
+      router.push(`/questions/${encodeURIComponent(value)}?${params.toString()}`);
     } else {
-      router.push("/");
+      router.push(`/?${params.toString()}`);
     }
   };
 

--- a/src/src/app/page.tsx
+++ b/src/src/app/page.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { useMemo, useState } from "react";
+import { useSearchParams, useRouter } from "next/navigation";
 
 import humanResults from "../../benchmark/results-human.json";
 
@@ -32,9 +33,24 @@ const ModelCell = ({ model }: { model: string }) => {
 
 export default function Home() {
   const results = useResults();
-  const [showRelative, setShowRelative] = useState(false);
+  const router = useRouter();
+  const searchParams = useSearchParams();
   const [selectedModels, setSelectedModels] = useState<string[]>([]);
   const [selectedProviders, setSelectedProviders] = useState<string[]>([]);
+  
+  // Read showRelative from URL query param
+  const showRelative = searchParams.get("relative") === "1";
+  
+  // Update showRelative by updating URL
+  const setShowRelative = (checked: boolean) => {
+    const params = new URLSearchParams(searchParams);
+    if (checked) {
+      params.set("relative", "1");
+    } else {
+      params.delete("relative");
+    }
+    router.push(`/?${params.toString()}`);
+  };
 
   const modelMetrics = useMemo(() => {
     const modelGroups = results.reduce(

--- a/src/src/app/questions/[pipename]/page.tsx
+++ b/src/src/app/questions/[pipename]/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { useParams } from "next/navigation";
+import { useParams, useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import benchmarkResults from "../../../../benchmark/results.json";
 import humanResults from "../../../../benchmark/results-human.json";
@@ -81,10 +81,23 @@ const ModelCell = ({ metric }: { metric: ModelMetrics }) => {
 
 export default function QuestionDetail() {
   const params = useParams();
+  const router = useRouter();
+  const searchParams = useSearchParams();
   const pipeName = decodeURIComponent(params.pipename as string);
   const [selectedModels, setSelectedModels] = useState<string[]>([]);
   const [selectedProviders, setSelectedProviders] = useState<string[]>([]);
-  const [showRelative, setShowRelative] = useState(false);
+  
+  const showRelative = searchParams.get("relative") === "1";
+  
+  const setShowRelative = (checked: boolean) => {
+    const params = new URLSearchParams(searchParams);
+    if (checked) {
+      params.set("relative", "1");
+    } else {
+      params.delete("relative");
+    }
+    router.push(`/questions/${encodeURIComponent(pipeName)}?${params.toString()}`);
+  };
 
   const modelResults = useMemo(() => {
     const questionResults = typedBenchmarkResults.filter(


### PR DESCRIPTION
Since the app doesn't use any Redux-like global state, I use in this MR a URL Query Parameter to propagate the state across navigation. Also it can be bookmarked.