### PR TITLE
Fix null safety in LLM review metrics parsing

### DIFF
--- a/.github/workflows/benchmark-append.yml
+++ b/.github/workflows/benchmark-append.yml
@@ -137,7 +137,8 @@ jobs:
           METRICS=$(curl -s "${TINYBIRD_API_HOST}/v0/pipes/api_model_metrics.json?include_unvalidated=1" \
             -H "Authorization: Bearer ${WORKSPACE_TOKEN}" | node -e "
             const data = JSON.parse(require('fs').readFileSync('/dev/stdin','utf8'));
-            const m = data.data.find(r => r.model === '${MODEL_NAME}' && r.provider === '${PROVIDER}');
+            const rows = data.data || [];
+            const m = rows.find(r => r.model === '${MODEL_NAME}' && r.provider === '${PROVIDER}');
             if (m) {
               console.log(JSON.stringify({
                 total: m.total_queries,


### PR DESCRIPTION
The LLM review step in `benchmark-append.yml` crashes when Tinybird returns an error or empty response. The `data.data.find(...)` call throws `TypeError: Cannot read properties of undefined` because `data.data` is undefined when the API response has no `data` property.

Fixed by using `data.data || []` so `.find()` gracefully returns undefined instead of crashing.

This was causing all 3 PRs from the latest discovery run to fail their review step.