### PR TITLE
Fix and harden auto-discover and benchmark workflows

### DIFF
--- a/.github/workflows/auto-discover-models.yml
+++ b/.github/workflows/auto-discover-models.yml
@@ -46,40 +46,38 @@ jobs:
         id: find-new-models
         working-directory: src
         run: |
-          # Run the check-new-models script
-          npm run check-new-models || {
-            # Script exits with code 1 when new models are found
-            if [ $? -eq 1 ]; then
-              # Read the new models JSON file
-              if [ -f "new-models.json" ]; then
-                NEW_MODELS=$(node -e "
-                  const fs = require('fs');
-                  const data = JSON.parse(fs.readFileSync('new-models.json', 'utf8'));
-                  console.log(data.models.map(m => m.provider + '/' + m.model).join(' '));
-                ")
-                
-                NEW_COUNT=$(node -e "
-                  const fs = require('fs');
-                  const data = JSON.parse(fs.readFileSync('new-models.json', 'utf8'));
-                  console.log(data.total_count);
-                ")
-                
-                echo "new_models=$NEW_MODELS" >> $GITHUB_OUTPUT
-                echo "new_count=$NEW_COUNT" >> $GITHUB_OUTPUT
-                echo "Found $NEW_COUNT new models: $NEW_MODELS"
-              else
-                echo "new_models=" >> $GITHUB_OUTPUT
-                echo "new_count=0" >> $GITHUB_OUTPUT
-              fi
+          EXIT_CODE=0
+          npm run check-new-models || EXIT_CODE=$?
+
+          if [ $EXIT_CODE -eq 0 ]; then
+            echo "new_models=" >> $GITHUB_OUTPUT
+            echo "new_count=0" >> $GITHUB_OUTPUT
+          elif [ $EXIT_CODE -eq 10 ]; then
+            if [ -f "new-models.json" ]; then
+              NEW_MODELS=$(node -e "
+                const fs = require('fs');
+                const data = JSON.parse(fs.readFileSync('new-models.json', 'utf8'));
+                console.log(data.models.map(m => m.provider + '/' + m.model).join(' '));
+              ")
+              NEW_COUNT=$(node -e "
+                const fs = require('fs');
+                const data = JSON.parse(fs.readFileSync('new-models.json', 'utf8'));
+                console.log(data.total_count);
+              ")
+              echo "new_models=$NEW_MODELS" >> $GITHUB_OUTPUT
+              echo "new_count=$NEW_COUNT" >> $GITHUB_OUTPUT
+              echo "Found $NEW_COUNT new models: $NEW_MODELS"
             else
-              echo "Error running check-new-models script"
-              echo "new_models=" >> $GITHUB_OUTPUT
-              echo "new_count=0" >> $GITHUB_OUTPUT
+              echo "::error::check-new-models exited 10 but new-models.json is missing"
+              exit 1
             fi
-          }
+          else
+            echo "::error::check-new-models failed with exit code $EXIT_CODE"
+            exit 1
+          fi
 
       - name: Commit updated untested models list
-        if: steps.find-new-models.outputs.new_count > 0
+        if: steps.find-new-models.outputs.new_count != '' && steps.find-new-models.outputs.new_count != '0'
         working-directory: src
         run: |
           git config --local user.email "action@github.com"
@@ -96,7 +94,7 @@ jobs:
           fi
 
       - name: Check for existing PRs and run benchmarks
-        if: steps.find-new-models.outputs.new_count > 0 && github.event.inputs.dry_run != 'true'
+        if: steps.find-new-models.outputs.new_count != '' && steps.find-new-models.outputs.new_count != '0' && github.event.inputs.dry_run != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -148,7 +146,8 @@ jobs:
           echo "  - Skipped (existing PRs): $SKIPPED_COUNT"
 
       - name: Log discovery results
-        if: steps.find-new-models.outputs.new_count > 0 || github.event.inputs.force_run == 'true'
+        if: steps.find-new-models.outputs.new_count != '' && steps.find-new-models.outputs.new_count != '0' || github.event.inputs.force_run == 'true'
+        working-directory: src
         run: |
           NEW_COUNT="${{ steps.find-new-models.outputs.new_count }}"
           NEW_MODELS="${{ steps.find-new-models.outputs.new_models }}"
@@ -175,9 +174,36 @@ jobs:
           fi
 
       - name: No new models found
-        if: steps.find-new-models.outputs.new_count == 0
+        if: steps.find-new-models.outputs.new_count == '' || steps.find-new-models.outputs.new_count == '0'
+        working-directory: src
         run: |
           echo "No new models found. All OpenRouter models are either tested or in the untested list."
           echo "Current status:"
           echo "- Tested models: $(node -e "const fs = require('fs'); const config = JSON.parse(fs.readFileSync('benchmark-config.json', 'utf8')); let count = 0; for (const data of Object.values(config.providers)) { count += data.models.length; } console.log(count);")"
           echo "- Untested models: $(node -e "const fs = require('fs'); const data = JSON.parse(fs.readFileSync('untested-models.json', 'utf8')); console.log(data.total_count);")"
+
+      - name: Job summary
+        if: always()
+        working-directory: src
+        run: |
+          NEW_COUNT="${{ steps.find-new-models.outputs.new_count }}"
+          NEW_MODELS="${{ steps.find-new-models.outputs.new_models }}"
+
+          TESTED=$(node -e "const fs = require('fs'); try { const c = JSON.parse(fs.readFileSync('benchmark-config.json','utf8')); let n=0; for (const d of Object.values(c.providers)) n+=d.models.length; console.log(n); } catch(e) { console.log('?'); }")
+          UNTESTED=$(node -e "const fs = require('fs'); try { const d = JSON.parse(fs.readFileSync('untested-models.json','utf8')); console.log(d.total_count); } catch(e) { console.log('?'); }")
+
+          echo "## Auto-Discovery Results" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Metric | Count |" >> $GITHUB_STEP_SUMMARY
+          echo "|--------|-------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Tested models | $TESTED |" >> $GITHUB_STEP_SUMMARY
+          echo "| Untested models | $UNTESTED |" >> $GITHUB_STEP_SUMMARY
+          echo "| New models found | ${NEW_COUNT:-0} |" >> $GITHUB_STEP_SUMMARY
+
+          if [ -n "$NEW_MODELS" ] && [ "$NEW_MODELS" != "" ]; then
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "### New models" >> $GITHUB_STEP_SUMMARY
+            for model in $NEW_MODELS; do
+              echo "- \`$model\`" >> $GITHUB_STEP_SUMMARY
+            done
+          fi

--- a/.github/workflows/benchmark-append.yml
+++ b/.github/workflows/benchmark-append.yml
@@ -38,24 +38,54 @@ jobs:
           WORKSPACE_TOKEN: ${{ secrets.WORKSPACE_TOKEN }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
 
+      - name: Verify benchmark quality
+        id: verify-quality
+        if: success()
+        working-directory: src
+        env:
+          TINYBIRD_API_HOST: ${{ vars.TINYBIRD_API_HOST }}
+          WORKSPACE_TOKEN: ${{ secrets.WORKSPACE_TOKEN }}
+        run: |
+          MODEL="${{ github.event.inputs.model }}"
+          PROVIDER=$(echo "$MODEL" | cut -d'/' -f1)
+          MODEL_NAME=$(echo "$MODEL" | cut -d'/' -f2-)
+
+          SUCCESS_RATE=$(curl -s "${TINYBIRD_API_HOST}/v0/pipes/api_model_metrics.json?include_unvalidated=1" \
+            -H "Authorization: Bearer ${WORKSPACE_TOKEN}" | node -e "
+            const data = JSON.parse(require('fs').readFileSync('/dev/stdin','utf8'));
+            const rows = data.data || [];
+            const m = rows.find(r => r.model === '${MODEL_NAME}' && r.provider === '${PROVIDER}');
+            console.log(m ? (m.success_rate * 100).toFixed(1) : '0');
+          ")
+
+          echo "Success rate for $MODEL: ${SUCCESS_RATE}%"
+          if (( $(echo "$SUCCESS_RATE < 20" | bc -l) )); then
+            echo "::error::Benchmark quality too low (${SUCCESS_RATE}% success rate)"
+            exit 1
+          fi
+
       - name: Report benchmark failure
-        if: failure() && steps.run-benchmark.outcome == 'failure'
+        if: failure() && (steps.run-benchmark.outcome == 'failure' || steps.verify-quality.outcome == 'failure')
         working-directory: src
         run: |
           MODEL="${{ github.event.inputs.model }}"
           PROVIDER=$(echo "$MODEL" | cut -d'/' -f1)
           MODEL_NAME=$(echo "$MODEL" | cut -d'/' -f2)
-          
-          echo "Benchmark failed for $MODEL"
+
+          REASON="Benchmark workflow failed"
+          if [ "${{ steps.verify-quality.outcome }}" = "failure" ]; then
+            REASON="Benchmark quality too low (success rate below 20%)"
+          fi
+
+          echo "Benchmark failed for $MODEL: $REASON"
           echo "Adding to failed models list..."
-          
-          # Add to failed models
-          npm run manage-failed-models add "$PROVIDER" "$MODEL_NAME" "$MODEL" "Benchmark workflow failed"
-          
+
+          npm run manage-failed-models add "$PROVIDER" "$MODEL_NAME" "$MODEL" "$REASON"
+
           echo "Model $MODEL has been added to the failed list"
 
       - name: Commit failure changes
-        if: failure() && steps.run-benchmark.outcome == 'failure'
+        if: failure() && (steps.run-benchmark.outcome == 'failure' || steps.verify-quality.outcome == 'failure')
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
@@ -79,7 +109,7 @@ jobs:
           fi
 
       - name: Create normalized branch name
-        if: success()
+        if: success() && steps.verify-quality.outcome == 'success'
         id: branch-name
         run: |
           MODEL_NAME="${{ github.event.inputs.model }}"
@@ -87,7 +117,7 @@ jobs:
           echo "branch_name=benchmark/$NORMALIZED_MODEL-${{ github.run_id }}" >> $GITHUB_OUTPUT
 
       - name: Create Pull Request
-        if: success()
+        if: success() && steps.verify-quality.outcome == 'success'
         id: create-pr
         uses: peter-evans/create-pull-request@v6
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -185,3 +185,7 @@ next-env.d.ts
 # Benchmark data (stored in Tinybird, local copies for debugging only)
 src/benchmark/results-human.json
 src/benchmark/validation-results.json
+
+# Auto-discovery artifacts
+src/new-models.json
+src/benchmark-new-models.sh

--- a/src/benchmark/check-new-models.ts
+++ b/src/benchmark/check-new-models.ts
@@ -68,34 +68,27 @@ function findNewModels(
   // Create sets for faster lookup
   const testedModels = new Set<string>();
   const untestedModels = new Set<string>();
-  const failedModels = new Set<string>();
-  
+
   // Add tested models to set
   for (const [provider, data] of Object.entries(config.providers)) {
     for (const model of data.models) {
       testedModels.add(`${provider}/${model}`);
     }
   }
-  
+
   // Add existing untested models to set
   for (const model of existingUntestedModels) {
     untestedModels.add(`${model.provider}/${model.model}`);
   }
-  
-  // Add failed models to set
-  const failedModelsList = loadFailedModels();
-  for (const model of failedModelsList) {
-    failedModels.add(`${model.provider}/${model.model}`);
-  }
-  
+
   // Check each OpenRouter model
   for (const model of openrouterModels) {
     const provider = extractProviderFromModelId(model.id);
     const modelName = model.id.includes("/") ? model.id.split("/")[1] : model.id;
     const modelKey = `${provider}/${modelName}`;
 
-    // If not tested, not in untested list, and not failed, it's new
-    if (!testedModels.has(modelKey) && !untestedModels.has(modelKey) && !failedModels.has(modelKey)) {
+    // If not tested and not in untested list, it's new
+    if (!testedModels.has(modelKey) && !untestedModels.has(modelKey)) {
       newModels.push({
         provider,
         model: modelName,
@@ -196,56 +189,8 @@ async function main() {
     writeFileSync("untested-models.json", JSON.stringify(untestedJson, null, 2));
     console.log(`📄 Refreshed untested models list: ${allUntested.length} models`);
     
-    // Generate a script to run benchmarks for new models
-    const benchmarkScript = `#!/bin/bash
-
-# Benchmark script for new OpenRouter models
-# Generated on ${new Date().toISOString()}
-
-echo "Starting benchmarks for ${newModels.length} new models..."
-
-# Array of new models to test
-models=(
-${newModels.map(m => `  "${m.provider}/${m.model}"`).join('\n')}
-)
-
-# Function to run benchmark for a single model
-run_benchmark() {
-  local model=\$1
-  echo "\\n=== Benchmarking \$model ==="
-  
-  # Run the benchmark
-  npm run benchmark -- --model="\$model" --debug
-  
-  # Check if benchmark was successful
-  if [ \$? -eq 0 ]; then
-    echo "✅ Benchmark completed successfully for \$model"
-  else
-    echo "❌ Benchmark failed for \$model"
-  fi
-  
-  # Add a small delay between benchmarks
-  sleep 2
-}
-
-# Run benchmarks for all new models
-for model in "\${models[@]}"; do
-  run_benchmark "\$model"
-done
-
-echo "\\n=== Benchmark completed ==="
-echo "Total new models tested: ${newModels.length}"
-`;
-
-    writeFileSync("benchmark-new-models.sh", benchmarkScript);
-    console.log("📝 Generated benchmark script: benchmark-new-models.sh");
-    
-    console.log("\n🚀 To run benchmarks for new models:");
-    console.log("   chmod +x benchmark-new-models.sh");
-    console.log("   ./benchmark-new-models.sh");
-    
-    // Exit with code 1 to indicate new models were found (useful for CI)
-    process.exit(1);
+    // Exit with code 10 to indicate new models were found (distinct from error code 1)
+    process.exit(10);
     
   } catch (error) {
     console.error("❌ Error:", error);

--- a/src/failed-models.json
+++ b/src/failed-models.json
@@ -1,30 +1,5 @@
 {
   "generated_at": "2026-05-05T14:00:06.081Z",
-  "total_count": 3,
-  "models": [
-    {
-      "provider": "x-ai",
-      "model": "grok-4.3",
-      "modelId": "x-ai/grok-4.3",
-      "reason": "PR rejected/closed without merging",
-      "failed_at": "2026-05-05T13:55:05.130Z",
-      "attempt_count": 1
-    },
-    {
-      "provider": "nvidia",
-      "model": "nemotron-3-nano-omni-30b-a3b-reasoning:free",
-      "modelId": "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free",
-      "reason": "PR rejected/closed without merging",
-      "failed_at": "2026-05-05T13:59:42.584Z",
-      "attempt_count": 1
-    },
-    {
-      "provider": "qwen",
-      "model": "qwen3.5-plus-20260420",
-      "modelId": "qwen/qwen3.5-plus-20260420",
-      "reason": "PR rejected/closed without merging",
-      "failed_at": "2026-05-05T14:00:06.081Z",
-      "attempt_count": 1
-    }
-  ]
+  "total_count": 0,
+  "models": []
 }


### PR DESCRIPTION
## Summary
- Fix ENOENT errors in discovery workflow logging steps (missing `working-directory: src`)
- Use distinct exit codes in `check-new-models.ts` (0=no new models, 10=new models found, 1=error) so the workflow can distinguish success from failure
- Add quality gate to `benchmark-append` that checks Tinybird success rate before creating PRs, preventing silent all-failure benchmarks from producing PRs
- Remove failed-models exclusion from discovery so transient failures get retried automatically
- Add job summary step for visibility in the GitHub Actions UI
- Clear `failed-models.json` to retry test models (grok-4.3, nemotron, qwen)

## Test plan
- [ ] Trigger auto-discover with `dry_run=true` — verify clean logs, no ENOENT, job summary renders
- [ ] Trigger auto-discover with `dry_run=false` — verify benchmarks trigger for cleared failed models
- [ ] Trigger benchmark-append for a known-bad model — verify quality gate catches it