### PR TITLE
Standardize Tinybird env vars and add credentials preflight check

### DIFF
--- a/.github/workflows/benchmark-append.yml
+++ b/.github/workflows/benchmark-append.yml
@@ -28,14 +28,27 @@ jobs:
         working-directory: src
         run: npm ci
 
+      - name: Verify Tinybird credentials
+        env:
+          TINYBIRD_API_HOST: ${{ vars.TINYBIRD_API_HOST }}
+          TINYBIRD_WORKSPACE_TOKEN: ${{ secrets.TINYBIRD_WORKSPACE_TOKEN }}
+        run: |
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+            "${TINYBIRD_API_HOST}/v0/sql?q=SELECT+1+FORMAT+JSON" \
+            -H "Authorization: Bearer ${TINYBIRD_WORKSPACE_TOKEN}")
+          if [ "$STATUS" != "200" ]; then
+            echo "::error::Tinybird credentials check failed (HTTP $STATUS). Check TINYBIRD_API_HOST and TINYBIRD_WORKSPACE_TOKEN."
+            exit 1
+          fi
+          echo "Tinybird credentials verified"
+
       - name: Run benchmark
         id: run-benchmark
         working-directory: src
         run: npm run benchmark -- --model="${{ github.event.inputs.model }}" --debug
         env:
           TINYBIRD_API_HOST: ${{ vars.TINYBIRD_API_HOST }}
-          TINYBIRD_WORKSPACE_TOKEN: ${{ secrets.WORKSPACE_TOKEN }}
-          WORKSPACE_TOKEN: ${{ secrets.WORKSPACE_TOKEN }}
+          TINYBIRD_WORKSPACE_TOKEN: ${{ secrets.TINYBIRD_WORKSPACE_TOKEN }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
 
       - name: Verify benchmark quality
@@ -44,14 +57,14 @@ jobs:
         working-directory: src
         env:
           TINYBIRD_API_HOST: ${{ vars.TINYBIRD_API_HOST }}
-          WORKSPACE_TOKEN: ${{ secrets.WORKSPACE_TOKEN }}
+          TINYBIRD_WORKSPACE_TOKEN: ${{ secrets.TINYBIRD_WORKSPACE_TOKEN }}
         run: |
           MODEL="${{ github.event.inputs.model }}"
           PROVIDER=$(echo "$MODEL" | cut -d'/' -f1)
           MODEL_NAME=$(echo "$MODEL" | cut -d'/' -f2-)
 
           SUCCESS_RATE=$(curl -s "${TINYBIRD_API_HOST}/v0/pipes/api_model_metrics.json?include_unvalidated=1" \
-            -H "Authorization: Bearer ${WORKSPACE_TOKEN}" | node -e "
+            -H "Authorization: Bearer ${TINYBIRD_WORKSPACE_TOKEN}" | node -e "
             const data = JSON.parse(require('fs').readFileSync('/dev/stdin','utf8'));
             const rows = data.data || [];
             const m = rows.find(r => r.model === '${MODEL_NAME}' && r.provider === '${PROVIDER}');
@@ -149,8 +162,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           TINYBIRD_API_HOST: ${{ vars.TINYBIRD_API_HOST }}
-          TINYBIRD_WORKSPACE_TOKEN: ${{ secrets.WORKSPACE_TOKEN }}
-          WORKSPACE_TOKEN: ${{ secrets.WORKSPACE_TOKEN }}
+          TINYBIRD_WORKSPACE_TOKEN: ${{ secrets.TINYBIRD_WORKSPACE_TOKEN }}
         run: |
           PR_NUMBER="${{ steps.create-pr.outputs.pull-request-number }}"
           MODEL="${{ github.event.inputs.model }}"
@@ -165,7 +177,7 @@ jobs:
 
           # Query Tinybird for benchmark metrics (include unvalidated results)
           METRICS=$(curl -s "${TINYBIRD_API_HOST}/v0/pipes/api_model_metrics.json?include_unvalidated=1" \
-            -H "Authorization: Bearer ${WORKSPACE_TOKEN}" | node -e "
+            -H "Authorization: Bearer ${TINYBIRD_WORKSPACE_TOKEN}" | node -e "
             const data = JSON.parse(require('fs').readFileSync('/dev/stdin','utf8'));
             const rows = data.data || [];
             const m = rows.find(r => r.model === '${MODEL_NAME}' && r.provider === '${PROVIDER}');

--- a/.github/workflows/benchmark-validate-on-merge.yml
+++ b/.github/workflows/benchmark-validate-on-merge.yml
@@ -49,8 +49,7 @@ jobs:
         working-directory: src
         env:
           TINYBIRD_API_HOST: ${{ vars.TINYBIRD_API_HOST }}
-          TINYBIRD_WORKSPACE_TOKEN: ${{ secrets.WORKSPACE_TOKEN }}
-          WORKSPACE_TOKEN: ${{ secrets.WORKSPACE_TOKEN }}
+          TINYBIRD_WORKSPACE_TOKEN: ${{ secrets.TINYBIRD_WORKSPACE_TOKEN }}
         run: |
           MODELS="${{ steps.models.outputs.models }}"
           for model in $MODELS; do

--- a/.github/workflows/tinybird-cd.yml
+++ b/.github/workflows/tinybird-cd.yml
@@ -9,10 +9,6 @@ on:
 
 concurrency: ${{ github.workflow }}-${{ github.event.ref }}
 
-env:
-  TINYBIRD_HOST: ${{ secrets.TINYBIRD_HOST }}
-  TINYBIRD_TOKEN: ${{ secrets.TINYBIRD_TOKEN }}
-
 jobs:
   cd:
     runs-on: ubuntu-latest
@@ -24,4 +20,4 @@ jobs:
       - name: Install Tinybird CLI
         run: curl https://tinybird.co | sh
       - name: Deploy project
-        run: tb --cloud --host ${{ env.TINYBIRD_HOST }} --token ${{ env.TINYBIRD_TOKEN }} deploy
+        run: tb --cloud --host ${{ vars.TINYBIRD_API_HOST }} --token ${{ secrets.TINYBIRD_WORKSPACE_TOKEN }} deploy

--- a/src/benchmark/index.ts
+++ b/src/benchmark/index.ts
@@ -543,21 +543,45 @@ async function revalidateModel(modelString: string) {
   console.log("Re-validation complete. Fresh validation data pushed to Tinybird.");
 }
 
+async function verifyTinybirdCredentials() {
+  const { tinybird } = getConfig();
+  if (!tinybird.apiHost || !tinybird.workspaceToken) {
+    console.error("TINYBIRD_API_HOST and TINYBIRD_WORKSPACE_TOKEN are required");
+    process.exit(1);
+  }
+
+  try {
+    const res = await fetch(`${tinybird.apiHost}/v0/sql?q=${encodeURIComponent("SELECT 1 FORMAT JSON")}`, {
+      headers: { Authorization: `Bearer ${tinybird.workspaceToken}` },
+    });
+    if (!res.ok) {
+      console.error(`Tinybird credentials check failed (HTTP ${res.status}): ${await res.text()}`);
+      process.exit(1);
+    }
+    console.log("Tinybird credentials verified");
+  } catch (err) {
+    console.error("Cannot connect to Tinybird:", err);
+    process.exit(1);
+  }
+}
+
 async function main() {
   const args = parseArgs();
-  
+
   // Show help if requested
   if (args.help) {
     printUsage();
     return;
   }
-  
+
   // Set debug mode if flag is provided
   if (args.debug) {
     process.env.LLM_DEBUG = '1';
     console.log('Debug mode enabled. LLM requests and responses will be logged.');
   }
-  
+
+  await verifyTinybirdCredentials();
+
   if (args.validate) {
     if (!args.model) {
       console.error("--validate requires --model=provider/model");


### PR DESCRIPTION
## Summary
- Standardize all workflows to use `TINYBIRD_WORKSPACE_TOKEN` (secret) and `TINYBIRD_API_HOST` (variable)
- Remove duplicate `WORKSPACE_TOKEN` env vars from benchmark workflows
- Update `tinybird-cd.yml` to use the same env vars instead of the old `TINYBIRD_HOST`/`TINYBIRD_TOKEN` secrets
- Add a Tinybird credentials verification step in `benchmark-append.yml` that runs before the benchmark, preventing wasted OpenRouter credits when Tinybird credentials are invalid
- Add the same preflight check in the benchmark Node code as a safety net

## Test plan
- [ ] Merge and trigger `benchmark-append` manually — should pass the "Verify Tinybird credentials" step
- [ ] Trigger auto-discover — benchmark runs should succeed end-to-end