### PR TITLE
Prioritize providers in discovery, increase batch size, fix success rate display

### DIFF
--- a/.github/workflows/auto-discover-models.yml
+++ b/.github/workflows/auto-discover-models.yml
@@ -14,7 +14,7 @@ on:
       max_models:
         description: "Maximum number of new models to benchmark (0 = no limit)"
         required: false
-        default: "5"
+        default: "15"
         type: string
       force_run:
         description: "Force run even if no new models found (for testing)"
@@ -82,47 +82,47 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           NEW_MODELS="${{ steps.find-new-models.outputs.new_models }}"
-          MAX_MODELS="${{ github.event.inputs.max_models || '5' }}"
+          MAX_MODELS="${{ github.event.inputs.max_models || '15' }}"
 
           echo "Checking for existing PRs and running benchmarks for new models: $NEW_MODELS"
           echo "Max models limit: $MAX_MODELS"
-          
-          # Convert to array and apply limit if specified
+
+          # Models are already sorted by provider priority (check-new-models.ts)
+          # Priority providers come first: anthropic, google, openai, mistralai, perplexity, x-ai, deepseek, meta-llama, moonshotai
           MODELS_ARRAY=($NEW_MODELS)
           if [ "$MAX_MODELS" != "0" ] && [ "$MAX_MODELS" -gt 0 ]; then
             MODELS_ARRAY=("${MODELS_ARRAY[@]:0:$MAX_MODELS}")
             echo "Limited to first $MAX_MODELS models: ${MODELS_ARRAY[*]}"
           fi
-          
+
           SKIPPED_COUNT=0
           TRIGGERED_COUNT=0
-          
+
           for model in "${MODELS_ARRAY[@]}"; do
             echo "=== Checking $model ==="
-            
+
             # Check if there's already an open PR for this model
             EXISTING_PR=$(gh pr list --state open --search "Add benchmark results for $model" --json number --jq '.[0].number' || echo "")
-            
+
             if [ -n "$EXISTING_PR" ] && [ "$EXISTING_PR" != "null" ]; then
               echo "⚠️  Open PR #$EXISTING_PR already exists for $model - skipping"
               SKIPPED_COUNT=$((SKIPPED_COUNT + 1))
               continue
             fi
-            
+
             echo "✅ No existing PR found for $model - triggering benchmark"
-            
-            # Trigger the benchmark-append workflow for this model
+
             gh workflow run benchmark-append.yml \
               --ref main \
               -f model="$model" \
               || echo "Failed to trigger workflow for $model"
-            
+
             TRIGGERED_COUNT=$((TRIGGERED_COUNT + 1))
-            
-            # Delay between triggers to avoid rate limits
-            sleep 60
+
+            # Short delay between triggers to avoid rate limits
+            sleep 10
           done
-          
+
           echo "📊 Summary:"
           echo "  - Models checked: ${#MODELS_ARRAY[@]}"
           echo "  - Benchmarks triggered: $TRIGGERED_COUNT"
@@ -135,7 +135,7 @@ jobs:
           NEW_COUNT="${{ steps.find-new-models.outputs.new_count }}"
           NEW_MODELS="${{ steps.find-new-models.outputs.new_models }}"
           DRY_RUN="${{ github.event.inputs.dry_run }}"
-          MAX_MODELS="${{ github.event.inputs.max_models || '5' }}"
+          MAX_MODELS="${{ github.event.inputs.max_models || '15' }}"
           FORCE_RUN="${{ github.event.inputs.force_run }}"
           
           if [ "$NEW_COUNT" -gt 0 ]; then

--- a/.github/workflows/benchmark-append.yml
+++ b/.github/workflows/benchmark-append.yml
@@ -68,7 +68,7 @@ jobs:
             const data = JSON.parse(require('fs').readFileSync('/dev/stdin','utf8'));
             const rows = data.data || [];
             const m = rows.find(r => r.model === '${MODEL_NAME}' && r.provider === '${PROVIDER}');
-            console.log(m ? (m.success_rate * 100).toFixed(1) : '0');
+            console.log(m ? (m.success_rate || 0).toFixed(1) : '0');
           ")
 
           echo "Success rate for $MODEL: ${SUCCESS_RATE}%"
@@ -187,8 +187,8 @@ jobs:
                 successful: m.successful_queries,
                 errors: m.total_queries - m.successful_queries,
                 avgLatency: (m.avg_total_duration || 0).toFixed(2),
-                successRate: ((m.success_rate || 0) * 100).toFixed(1),
-                firstAttemptRate: ((m.first_attempt_rate || 0) * 100).toFixed(1),
+                successRate: (m.success_rate || 0).toFixed(1),
+                firstAttemptRate: (m.first_attempt_rate || 0).toFixed(1),
                 avgExecutionTime: (m.avg_execution_time || 0).toFixed(4)
               }));
             } else {

--- a/src/benchmark/check-new-models.ts
+++ b/src/benchmark/check-new-models.ts
@@ -16,6 +16,38 @@ interface NewModel {
   created?: number;
 }
 
+const PRIORITY_PROVIDERS = [
+  "anthropic",
+  "google",
+  "openai",
+  "mistralai",
+  "perplexity",
+  "x-ai",
+  "deepseek",
+  "meta-llama",
+  "moonshotai",
+];
+
+function sortByProviderPriority(models: NewModel[]): NewModel[] {
+  const prioritySet = new Set(PRIORITY_PROVIDERS);
+  const priority: NewModel[] = [];
+  const rest: NewModel[] = [];
+
+  for (const m of models) {
+    if (prioritySet.has(m.provider)) {
+      priority.push(m);
+    } else {
+      rest.push(m);
+    }
+  }
+
+  priority.sort((a, b) => {
+    return PRIORITY_PROVIDERS.indexOf(a.provider) - PRIORITY_PROVIDERS.indexOf(b.provider);
+  });
+
+  return [...priority, ...rest];
+}
+
 async function loadBenchmarkConfig(): Promise<BenchmarkConfig> {
   try {
     const configPath = "benchmark-config.json";
@@ -67,7 +99,7 @@ async function main() {
     const config = await loadBenchmarkConfig();
     const testedCount = Object.values(config.providers).reduce((sum, data) => sum + data.models.length, 0);
 
-    const newModels = findNewModels(openrouterModels, config);
+    const newModels = sortByProviderPriority(findNewModels(openrouterModels, config));
 
     console.log(`📊 Found ${newModels.length} untested models:\n`);
 
@@ -79,18 +111,36 @@ async function main() {
       return;
     }
 
-    const groupedByProvider = newModels.reduce((acc, model) => {
-      if (!acc[model.provider]) {
-        acc[model.provider] = [];
-      }
-      acc[model.provider].push(model);
-      return acc;
-    }, {} as Record<string, NewModel[]>);
+    const prioritySet = new Set(PRIORITY_PROVIDERS);
+    const priorityModels = newModels.filter(m => prioritySet.has(m.provider));
+    const otherModels = newModels.filter(m => !prioritySet.has(m.provider));
 
-    for (const [provider, models] of Object.entries(groupedByProvider)) {
-      console.log(`📁 ${provider} (${models.length} models):`);
-      for (const model of models) {
-        console.log(`  - ${model.model} (${model.modelId})`);
+    if (priorityModels.length > 0) {
+      console.log(`⭐ Priority providers (${priorityModels.length} models):`);
+      const grouped = priorityModels.reduce((acc, m) => {
+        (acc[m.provider] ??= []).push(m);
+        return acc;
+      }, {} as Record<string, NewModel[]>);
+      for (const [provider, models] of Object.entries(grouped)) {
+        console.log(`  📁 ${provider} (${models.length}):`);
+        for (const model of models) {
+          console.log(`    - ${model.model}`);
+        }
+      }
+      console.log();
+    }
+
+    if (otherModels.length > 0) {
+      console.log(`📁 Other providers (${otherModels.length} models):`);
+      const grouped = otherModels.reduce((acc, m) => {
+        (acc[m.provider] ??= []).push(m);
+        return acc;
+      }, {} as Record<string, NewModel[]>);
+      for (const [provider, models] of Object.entries(grouped)) {
+        console.log(`  📁 ${provider} (${models.length}):`);
+        for (const model of models) {
+          console.log(`    - ${model.model}`);
+        }
       }
       console.log();
     }


### PR DESCRIPTION
## Summary

- **Provider prioritization**: New models from anthropic, google, openai, mistralai, perplexity, x-ai, deepseek, meta-llama, moonshotai are now sorted first in each discovery batch. Priority providers always get tested before lesser-known ones.
- **Larger batches**: Default `max_models` increased from 5 to 15 per daily run. Sleep between workflow triggers reduced from 60s to 10s.
- **Success rate fix**: Removed double multiplication of `success_rate` in `benchmark-append.yml` (Tinybird already returns a percentage, workflow was multiplying by 100 again, causing 10000% display in PR comments and a broken quality gate).

## Test plan

- [ ] Run auto-discover with `dry_run=true` and verify priority providers appear first in logs
- [ ] Trigger a benchmark-append run and verify the PR comment shows correct success rate (not 10000%)
- [ ] Verify quality gate still catches low success rates correctly