### PR TITLE
Batch benchmark results for missed merge validations

### DIFF
--- a/.github/workflows/benchmark-validate-on-merge.yml
+++ b/.github/workflows/benchmark-validate-on-merge.yml
@@ -5,6 +5,10 @@ on:
     types: [closed]
     branches: [main]
 
+concurrency:
+  group: benchmark-validation-main
+  cancel-in-progress: false
+
 jobs:
   validate:
     if: >

--- a/src/benchmark-runs/anthropic__claude-opus-4.json
+++ b/src/benchmark-runs/anthropic__claude-opus-4.json
@@ -1,0 +1,1 @@
+{"model":"anthropic/claude-opus-4","run_id":27751139372,"timestamp":"2026-06-18T10:29:32Z"}

--- a/src/benchmark-runs/google__gemma-3-12b-it.json
+++ b/src/benchmark-runs/google__gemma-3-12b-it.json
@@ -1,0 +1,1 @@
+{"model":"google/gemma-3-12b-it","run_id":27540072015,"timestamp":"2026-06-15T10:37:24Z"}

--- a/src/benchmark-runs/google__gemma-3-27b-it.json
+++ b/src/benchmark-runs/google__gemma-3-27b-it.json
@@ -1,0 +1,1 @@
+{"model":"google/gemma-3-27b-it","run_id":25596986242,"timestamp":"2026-05-11T07:47:41Z"}

--- a/src/benchmark-runs/google__gemma-3n-e4b-it.json
+++ b/src/benchmark-runs/google__gemma-3n-e4b-it.json
@@ -1,0 +1,1 @@
+{"model":"google/gemma-3n-e4b-it","run_id":25426559220,"timestamp":"2026-06-15T06:49:02Z"}

--- a/src/benchmark-runs/meta-llama__llama-3.1-8b-instruct.json
+++ b/src/benchmark-runs/meta-llama__llama-3.1-8b-instruct.json
@@ -1,0 +1,1 @@
+{"model":"meta-llama/llama-3.1-8b-instruct","run_id":27540136130,"timestamp":"2026-06-15T10:38:33Z"}

--- a/src/benchmark-runs/mistralai__mistral-large-2512.json
+++ b/src/benchmark-runs/mistralai__mistral-large-2512.json
@@ -1,0 +1,1 @@
+{"model":"mistralai/mistral-large-2512","run_id":27751200913,"timestamp":"2026-06-18T10:30:32Z"}

--- a/src/benchmark-runs/openai__gpt-5.1-chat.json
+++ b/src/benchmark-runs/openai__gpt-5.1-chat.json
@@ -1,0 +1,1 @@
+{"model":"openai/gpt-5.1-chat","run_id":27751180547,"timestamp":"2026-06-18T10:29:52Z"}

--- a/src/benchmark-runs/openai__gpt-oss-20b:free.json
+++ b/src/benchmark-runs/openai__gpt-oss-20b:free.json
@@ -1,0 +1,1 @@
+{"model":"openai/gpt-oss-20b:free","run_id":26503030116,"timestamp":"2026-05-27T09:44:30Z"}

--- a/src/benchmark-runs/poolside__laguna-xs.2:free.json
+++ b/src/benchmark-runs/poolside__laguna-xs.2:free.json
@@ -1,0 +1,1 @@
+{"model":"poolside/laguna-xs.2:free","run_id":27680874174,"timestamp":"2026-06-17T10:25:52Z"}


### PR DESCRIPTION
**Models benchmarked:**
anthropic/claude-opus-4 openai/gpt-5.1-chat mistralai/mistral-large-2512 poolside/laguna-xs.2:free meta-llama/llama-3.1-8b-instruct google/gemma-3-12b-it google/gemma-3n-e4b-it openai/gpt-oss-20b:free google/gemma-3-27b-it

This PR replays the benchmark result validation for every failed `Validate benchmark results on merge` run found in the available GitHub Actions history. In each case, the workflow reached the Tinybird validation step but failed while pushing config/cleanup changes back to main.

It also serializes the merge-validation workflow with a concurrency group so future validations do not race each other when updating main.
