### PR TITLE
fix: cap resources on benchmark queries to protect ClickHouse instance

### DIFF
--- a/src/benchmark/client.ts
+++ b/src/benchmark/client.ts
@@ -55,11 +55,21 @@ function extractSqlQuery(output: string | null | undefined): string | null {
 export function getClient() {
   const { tinybird } = getConfig();
 
+  // Per-query resource caps so a model's unoptimized SQL can't saturate the
+  // shared ClickHouse instance. Exceeding a cap fails the query, which is the
+  // correct benchmark outcome for an unrunnable query.
+  const QUERY_CAPS =
+    "max_execution_time=30, max_threads=2, max_memory_usage=8000000000";
+
   async function executeSqlQuery(sql: string): Promise<SqlResult> {
     const startTime = Date.now();
 
+    const cappedSql = /\bSETTINGS\b/i.test(sql)
+      ? sql
+      : `${sql} SETTINGS ${QUERY_CAPS}`;
+
     const url = `${tinybird.apiHost}/v0/sql?q=${encodeURIComponent(
-      sql
+      cappedSql
     )} FORMAT JSON`;
 
     const response = await fetch(url, {


### PR DESCRIPTION
## Problem

The benchmarked LLMs generate arbitrary SQL against the 200M-row `github_events` table and run it via the Tinybird Query API. Those queries were **uncapped**.

On 2026-07-26 this triggered an on-call alert (ClickHouse connection time too high on the `gcp-europe-west2` public reader instance). Digging into the workspace's own `pipe_stats_rt` showed the cause was **not** ingestion or the website's display endpoints (those used <20 CPU-seconds all day) — it was `query_api`:

| pipe | requests | total CPU-s | GB read |
|---|---|---|---|
| **query_api** (benchmark SQL) | 2,080 | **12,810** | **1,517** |
| all `api_*` display endpoints | ~290 | <20 | ~5 |

The load hit in a ~20-minute burst around the alert, at ~30 queries running concurrently. Single queries read tens of GB and burned 200+ CPU-seconds each.

## Fix

We can't trust the generated query to be efficient, so we bound what any single execution is allowed to consume. Every benchmark query now runs with:

```
SETTINGS max_execution_time=30, max_threads=2, max_memory_usage=8000000000
```

- **Runaway runtime** → killed at 30s
- **CPU hogging** → max 2 threads per query, so concurrent jobs can't oversubscribe cores
- **Memory blowup** → capped at 8GB, can't OOM

A query that exceeds a cap fails, which is the **correct** benchmark outcome for an unrunnable query — it's recorded as a failure for that model, and the existing retry loop feeds the error back so the model can self-correct toward a lighter query.

## Validation

Ran the exact offending queries from the incident with the new caps:

| Query (from the burst) | Uncapped (recorded 07-26) | Capped |
|---|---|---|
| `COUNT(DISTINCT … CASE)` over full table | 78.9s, 257 CPU-s, 2.4GB | **killed at 6.7s** (memory cap) |
| `match()` regex full-scan | 64.7s, 236 CPU-s, 34.5GB | **killed at 30s** (time cap) |

## Notes / follow-ups

- Scope: one spot, `src/benchmark/client.ts`. Applies to both the warming and the measured query.
- The caps live in the SQL, so if a model emits its own `SETTINGS` clause (rare — the prompt asks for a bare SELECT/WITH) ours are skipped. For a truly unbypassable limit, set the same caps as **token-level limits** on the workspace token in Tinybird. Recommended as belt-and-suspenders.