### PR TITLE
Batch benchmark results for 8 recovered models

### DIFF
--- a/.github/workflows/benchmark-append.yml
+++ b/.github/workflows/benchmark-append.yml
@@ -126,8 +126,10 @@ jobs:
         id: branch-name
         run: |
           MODEL_NAME="${{ github.event.inputs.model }}"
-          NORMALIZED_MODEL=$(echo "$MODEL_NAME" | sed 's/[\/\s_\.:]/-/g')
-          echo "branch_name=benchmark/$NORMALIZED_MODEL-${{ github.run_id }}" >> $GITHUB_OUTPUT
+          NORMALIZED_MODEL=$(printf '%s' "$MODEL_NAME" | sed -E 's/[^[:alnum:]]+/-/g; s/^-+//; s/-+$//')
+          BRANCH_NAME="benchmark/$NORMALIZED_MODEL-${{ github.run_id }}"
+          git check-ref-format --branch "$BRANCH_NAME"
+          echo "branch_name=$BRANCH_NAME" >> "$GITHUB_OUTPUT"
 
       - name: Create benchmark branch
         if: success() && steps.verify-quality.outcome == 'success'

--- a/src/benchmark-runs/~anthropic__claude-haiku-latest.json
+++ b/src/benchmark-runs/~anthropic__claude-haiku-latest.json
@@ -1,0 +1,1 @@
+{"model":"~anthropic/claude-haiku-latest","run_id":30992452604,"timestamp":"2026-08-05T09:21:03Z"}

--- a/src/benchmark-runs/~anthropic__claude-opus-latest.json
+++ b/src/benchmark-runs/~anthropic__claude-opus-latest.json
@@ -1,0 +1,1 @@
+{"model":"~anthropic/claude-opus-latest","run_id":30992524403,"timestamp":"2026-08-05T09:22:33Z"}

--- a/src/benchmark-runs/~deepseek__deepseek-v4-flash-latest.json
+++ b/src/benchmark-runs/~deepseek__deepseek-v4-flash-latest.json
@@ -1,0 +1,1 @@
+{"model":"~deepseek/deepseek-v4-flash-latest","run_id":30992424192,"timestamp":"2026-08-05T11:00:47Z"}

--- a/src/benchmark-runs/~google__gemini-flash-latest.json
+++ b/src/benchmark-runs/~google__gemini-flash-latest.json
@@ -1,0 +1,1 @@
+{"model":"~google/gemini-flash-latest","run_id":30992510558,"timestamp":"2026-08-05T09:24:21Z"}

--- a/src/benchmark-runs/~google__gemini-pro-latest.json
+++ b/src/benchmark-runs/~google__gemini-pro-latest.json
@@ -1,0 +1,1 @@
+{"model":"~google/gemini-pro-latest","run_id":30992482651,"timestamp":"2026-08-05T09:24:28Z"}

--- a/src/benchmark-runs/~moonshotai__kimi-latest.json
+++ b/src/benchmark-runs/~moonshotai__kimi-latest.json
@@ -1,0 +1,1 @@
+{"model":"~moonshotai/kimi-latest","run_id":30992496422,"timestamp":"2026-08-05T09:29:40Z"}

--- a/src/benchmark-runs/~openai__gpt-mini-latest.json
+++ b/src/benchmark-runs/~openai__gpt-mini-latest.json
@@ -1,0 +1,1 @@
+{"model":"~openai/gpt-mini-latest","run_id":30992467892,"timestamp":"2026-08-05T09:20:19Z"}

--- a/src/benchmark-runs/~x-ai__grok-latest.json
+++ b/src/benchmark-runs/~x-ai__grok-latest.json
@@ -1,0 +1,1 @@
+{"model":"~x-ai/grok-latest","run_id":30992438057,"timestamp":"2026-08-05T09:24:09Z"}


### PR DESCRIPTION
Closes GRO-1361

Recovers eight successful benchmark runs whose branch creation failed after their results were already pushed to Tinybird.

**Models benchmarked:**
~deepseek/deepseek-v4-flash-latest ~x-ai/grok-latest ~anthropic/claude-haiku-latest ~openai/gpt-mini-latest ~google/gemini-pro-latest ~moonshotai/kimi-latest ~google/gemini-flash-latest ~anthropic/claude-opus-latest

This PR also fixes branch normalization for OpenRouter alias IDs:

- replaces every run of non-alphanumeric characters with one hyphen
- preserves letters such as `s`
- validates the generated ref before creating the branch

No benchmark queries were rerun. Merging this PR will validate the existing Tinybird results through the batch validation workflow.